### PR TITLE
Mention required npx version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can configure your bundler options in the `build` script in `package.json` o
 
 ## Installation
 
-You must already have node and yarn installed on your system. Then:
+You must already have node and yarn installed on your system. You will also need npx version 7.1.0 or later. Then:
 
 1. Add `jsbundling-rails` to your Gemfile with `gem 'jsbundling-rails'`
 2. Run `./bin/bundle install`


### PR DESCRIPTION
`set-script` was not part of `npx` until version 7.1.0 (https://github.com/npm/cli/releases/tag/v7.1.0) which was "only" released December 2020.

I cannot speak for JavaScript developers, but I have a feeling Rails developers don't update their nodes or npxes often. I know for a fact stock node 14 (active LTS) comes with only version 6 of `npx`.

This adds a note to the readme about the required minimal version.

cssbundling-rails will probably need this as well.